### PR TITLE
Parse backtick code blocks inside tables

### DIFF
--- a/src/components/blocks/Table/Component.astro
+++ b/src/components/blocks/Table/Component.astro
@@ -4,6 +4,7 @@ import { TableFragment } from './graphql';
 import { parseShortCodes, toCss } from './utils';
 import { readFragment } from 'gql.tada';
 import s from './style.module.css';
+import { backticksToHtmlCodeBlock } from '~/lib/backticksToHtmlCodeBlock.ts';
 
 interface Props {
   block: FragmentOf<typeof TableFragment>;
@@ -28,14 +29,18 @@ const columns = table.columns.map((rawName) => parseShortCodes(rawName, ['style'
     <table>
       <thead>
         <tr>
-          {columns.map((col) => <th style={toCss(col.meta.style)}>{col.content}</th>)}
+          {
+            columns.map((col) => (
+              <th style={toCss(col.meta.style)} set:html={backticksToHtmlCodeBlock(col.content)} />
+            ))
+          }
         </tr>
       </thead>
       {
         table.data.map((row) => (
           <tr>
             {columns.map((col) => (
-              <td style={toCss(col.meta.style)}>{row[col.id]}</td>
+              <td style={toCss(col.meta.style)} set:html={backticksToHtmlCodeBlock(row[col.id])} />
             ))}
           </tr>
         ))

--- a/src/components/blocks/Table/Component.astro
+++ b/src/components/blocks/Table/Component.astro
@@ -22,6 +22,8 @@ type TableData<T extends string> = {
 const table = block.table as TableData<string>;
 
 const columns = table.columns.map((rawName) => parseShortCodes(rawName, ['style']));
+
+const addLineBreaks = (input: string): string => input.replace(/[\n\r]/g, '<br/>');
 ---
 
 <figure>
@@ -40,7 +42,10 @@ const columns = table.columns.map((rawName) => parseShortCodes(rawName, ['style'
         table.data.map((row) => (
           <tr>
             {columns.map((col) => (
-              <td style={toCss(col.meta.style)} set:html={backticksToHtmlCodeBlock(row[col.id])} />
+              <td
+                style={toCss(col.meta.style)}
+                set:html={addLineBreaks(backticksToHtmlCodeBlock(row[col.id]))}
+              />
             ))}
           </tr>
         ))

--- a/src/lib/backticksToHtmlCodeBlock.ts
+++ b/src/lib/backticksToHtmlCodeBlock.ts
@@ -1,0 +1,20 @@
+import { escape as escapeHtml } from 'lodash-es';
+
+/**
+ * Converts text wrapped in backticks within a string to HTML code blocks.
+ *
+ * Escapes HTML chars within the input string (using lodash's escape() func)
+ * then replaces instances of backtick-wrapped text with HTML `<code>` tags.
+ *
+ *
+ * @param {string} input - The input string containing text with potential backtick-wrapped sections.
+ * @returns {string} - The input string with backtick-wrapped sections converted to `<code>` blocks.
+ */
+export const backticksToHtmlCodeBlock = (input?: string): string => {
+  if (!input) {
+    return '';
+  }
+  const escapedInput = escapeHtml(input);
+  const backticksToCodeBlocks = escapedInput.replace(/`([^`]+?)`/g, '<code>$1</code>');
+  return backticksToCodeBlocks;
+};


### PR DESCRIPTION
Simple change that allows us to use code formatting inside tables

## Before
![Screenshot 000735](https://github.com/user-attachments/assets/6521a762-2001-469e-8336-3c53156f2b10)

## After
![Screenshot 000734](https://github.com/user-attachments/assets/96a3d823-99f1-4107-ae3b-1cccf31d8d98)
