### PR TITLE
Potential hotfix for Posthog analytics stalling...

### DIFF
--- a/src/pages/landing-pages/cookieConsent.js.ts
+++ b/src/pages/landing-pages/cookieConsent.js.ts
@@ -58,14 +58,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-TJRM9NT');
 `;
 
+//language=js (please leave this line... it's for IDE syntax highlighting of the following template literal)
 const cookieConsentScript = `
 (() => {
   const scriptsToAddOnCookieConsent = \`${scriptsToAddOnCookieConsent}\`;
 
   function addScripts() {
-    const script = document.createElement('script');
-    script.appendChild(document.createTextNode(scriptsToAddOnCookieConsent));
-    document.getElementsByTagName('head')[0].appendChild(script);
+    try {
+      const script = document.createElement('script');
+      script.appendChild(document.createTextNode(scriptsToAddOnCookieConsent));
+      document.getElementsByTagName('head')[0].appendChild(script);
+    } catch (error) {
+      console.error('Unable to add cookie scripts', error);
+    }
   }
 
   function onReady(cb) {


### PR DESCRIPTION
(Hotfix)

Wrap some third party analytics calls in a try block to prevent them from stalling the window on network failures.

TODO:

- Add better Rollbar error tracking for this middleware
- Add GTM (googletagmanager.com) to content security policy allow list
- (Maybe) Audit this repo for similar points of failure (wrap them all in try/catch)?