### PR TITLE
Redirect documentation --> docs to fix broken link

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -263,5 +263,6 @@ export default defineConfig({
     '/docs/deployments/netlify': '/marketplace/hosting/netlify',
     '/docs/plugins/creating-a-new-plugin': '/docs/plugin-sdk/build-your-first-plugin',
     '/docs/visual-editing/how-to-use-visual-editing': '/docs/content-link/how-to-use-content-link',
+    '/documentation': '/docs',
   },
 });

--- a/src/pages/features/dynamic-layouts/index.astro
+++ b/src/pages/features/dynamic-layouts/index.astro
@@ -121,7 +121,7 @@ if (!page) {
         </li>
         <li>
           <Svg name="icons/regular/check" />
-          <a href="/features/headless-cms-multi-languag" title="Headless CMS multilanguage">
+          <a href="/features/headless-cms-multi-language" title="Headless CMS multilanguage">
             <span>A complete set of multilanguage features</span>
           </a>
         </li>


### PR DESCRIPTION
Fixes a couple broken links:

![404 - Page Not Found - 2025-03-26 11-41-16 AM](https://github.com/user-attachments/assets/cf284a7e-58d2-4617-8bb1-9bb3e69a32fb)

I'll update it in the CMS too, but also updating the redirects just in case. It seems to be affecting a lot of pages and I'm not confident I can find them all in the CMS:

![Broken – Dr  Link Check - 2025-03-26 11-44-42 AM](https://github.com/user-attachments/assets/488a95bf-952e-4857-bc8a-e9874b169ec2)

Edit: Also fixed another 404: ![Component based CMS - DatoCMS headless website builder - 2025-03-26 11-53-38 AM](https://github.com/user-attachments/assets/158d08ae-93f4-4800-9818-770e619e1df2)
