### PR TITLE
Fix for docs react-ui components not showing up at all

### DIFF
--- a/src/components/docs/blocks/ReactUiLiveExample/Component.astro
+++ b/src/components/docs/blocks/ReactUiLiveExample/Component.astro
@@ -37,10 +37,7 @@ const componentExamples = examples.filter((example) => example.componentName ===
             <Tabs>
               <Tab title="Preview">
                 <div class={s.liveExample}>
-                  <LiveExample
-                    serializedMdxExample={example.serializedMdxExample}
-                    client:only="react"
-                  />
+                  <LiveExample serializedMdxExample={example.serializedMdxExample} />
                 </div>
               </Tab>
               <Tab title="Code" noPadding>


### PR DESCRIPTION
Fix for https://3.basecamp.com/5656352/buckets/33592490/card_tables/cards/8712926076

React-ui components weren't showing up in docs. Seems like the [directive `client:only='react'`](https://docs.astro.build/en/reference/directives-reference/#clientonly) wasn't quite working the way we expected.

## Before
![Form  Documentation — DatoCMS - 2025-06-02 12-13-22 PM](https://github.com/user-attachments/assets/be6c8dc4-f38b-4948-b448-49ed060fedd7)

## After
![Form  Documentation — DatoCMS - 2025-06-02 12-13-35 PM](https://github.com/user-attachments/assets/d8dcf746-298e-4b44-a24d-3ee1dd256aea)
