### PR TITLE
Explicitly set next-remote-mdx development mode off in prod.

### DIFF
--- a/src/components/docs/blocks/ReactUiLiveExample/utils.ts
+++ b/src/components/docs/blocks/ReactUiLiveExample/utils.ts
@@ -61,7 +61,9 @@ async function buildReactUiExamples(): Promise<ReactUiLiveExample[]> {
             code: codeWithoutMarkdown,
             title: example.name,
             description,
-            serializedMdxExample: await serialize(codeWithoutMarkdown),
+            serializedMdxExample: await serialize(codeWithoutMarkdown, {
+              mdxOptions: { development: import.meta?.env?.DEV ?? false },
+            }),
           },
         ];
       });


### PR DESCRIPTION
See https://stackoverflow.com/questions/74807529/jsxdev-is-not-a-function-when-using-mdxremote

It's still trying to load __jsxDEV in prod.