### PR TITLE
Add redirect from plugins-sdk to plugins-sdk/introduction.

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -271,5 +271,6 @@ export default defineConfig({
     '/docs/content-delivery-api/tree-like-collections':
       '/docs/content-delivery-api/hierarchical-sorting',
     '/docs/content-modelling/trees': '/docs/content-modelling/hierarchical-sorting',
+    '/docs/plugin-sdk': '/docs/plugin-sdk/introduction',
   },
 });


### PR DESCRIPTION
Add redirect from plugins-sdk to plugins-sdk/introduction. The plugins SDK repo and possibly other sources still link to the old version without the /introduction.