### PR TITLE
Revert "Fix for docs react-ui components not showing up at all"

### DIFF
--- a/src/components/docs/blocks/ReactUiLiveExample/Component.astro
+++ b/src/components/docs/blocks/ReactUiLiveExample/Component.astro
@@ -37,7 +37,10 @@ const componentExamples = examples.filter((example) => example.componentName ===
             <Tabs>
               <Tab title="Preview">
                 <div class={s.liveExample}>
-                  <LiveExample serializedMdxExample={example.serializedMdxExample} />
+                  <LiveExample
+                    serializedMdxExample={example.serializedMdxExample}
+                    client:only="react"
+                  />
                 </div>
               </Tab>
               <Tab title="Code" noPadding>


### PR DESCRIPTION
Reverts datocms/astro-website#50

@stefanoverna added `client:only="react"` to fix a couple of views where dropdowns and other components were breaking. I also think that it's logical to load the `<LiveExample>`s only on the client.