### PR TITLE
[Docs] Fix: Some examples didn't have titles and were causing page crashes

### DIFF
--- a/src/components/docs/restApi/EndpointDescriptionWithExamples/index.ts
+++ b/src/components/docs/restApi/EndpointDescriptionWithExamples/index.ts
@@ -71,17 +71,21 @@ export function buildTocGroupsFromExamples(
   const headings: TocEntry[] = [];
 
   for (const example of examplesInMarkdown(examples, content)) {
-    headings.push({
-      label: example.title,
-      url: `#${example.id}`,
-    });
+    if (example?.title) {
+      headings.push({
+        label: example.title,
+        url: `#${example.id}`,
+      });
+    }
   }
 
   for (const example of examplesNotInMarkdown(examples, content)) {
-    headings.push({
-      label: example.title,
-      url: `#${example.id}`,
-    });
+    if (example?.title) {
+      headings.push({
+        label: example.title,
+        url: `#${example.id}`,
+      });
+    }
   }
 
   if (examples.length === 0) {

--- a/src/components/docs/restApi/types.ts
+++ b/src/components/docs/restApi/types.ts
@@ -22,7 +22,7 @@ export type RestApiEndpointHttpExample = {
 
 export type RestApiEndpointJsExample = {
   id: string;
-  title: string;
+  title?: string;
   description: string;
   request?: {
     description?: string;


### PR DESCRIPTION
We were trying to iterate through some examples that had an incorrect TypeScript. We thought their `title` was required but some are actually missing one. This caused the page to crash and a server 503.

## Before

On prod:
<img width="427" height="244" alt="503 backend read error - 2025-09-25 11-11-47 AM" src="https://github.com/user-attachments/assets/fa70fcba-be5e-44ec-9d41-620b0db0add4" />

Or locally:
<img width="1246" height="547" alt="Create a new record — Record — Content Management API — DatoCMS - 2025-09-25 11-12-12 AM" src="https://github.com/user-attachments/assets/d4623092-87ed-4868-bbd8-9b2f7d3d2b23" />

## After
<img width="1704" height="1244" alt="Create a new record — Record — Content Management API — DatoCMS - 2025-09-25 11-12-35 AM" src="https://github.com/user-attachments/assets/c7447ba8-6140-4409-9f39-c2443fa279c3" />
