### PR TITLE
Add explicit warning to Dashboard API endpoints

### DIFF
--- a/src/pages/docs/dashboard-api/components/_DashboardExperimentalAPIWarning.astro
+++ b/src/pages/docs/dashboard-api/components/_DashboardExperimentalAPIWarning.astro
@@ -1,0 +1,11 @@
+---
+import DocCalloutBase from '~/components/docs/blocks/DocCallout/Base.astro';
+---
+
+<DocCalloutBase calloutType="warning" title="Warning: Experimental API">
+  <p>
+    Please note that the Dashboard API is an experimental, prerelease API. This API method is
+    considered unstable, and should be avoided in production environments and automations. Changes
+    may occur at any time without warning.
+  </p>
+</DocCalloutBase>

--- a/src/pages/docs/dashboard-api/resources/[entitySlug]/[endpointRel]/index.astro
+++ b/src/pages/docs/dashboard-api/resources/[entitySlug]/[endpointRel]/index.astro
@@ -35,7 +35,7 @@ import {
   seoPageTitle,
   seoShareTitle,
 } from '~/lib/datocms/seo';
-import DocCalloutBase from '~/components/docs/blocks/DocCallout/Base.astro';
+import DashboardExperimentalAPIWarning from '../../../components/_DashboardExperimentalAPIWarning.astro';
 
 const sidebarItems = await buildDashboardSidebarItems(Astro, Astro.params.entitySlug!);
 const entity = await findDashboardEntity(Astro, Astro.params.entitySlug!);
@@ -126,19 +126,7 @@ const propsForExamples = { entity, endpoint, jsClient, api: 'dashboard-api' as c
     <Fragment slot="kicker">Dashboard API > {entity.title}</Fragment>
     <Fragment slot="title">{endpoint.title}</Fragment>
 
-    {
-      !!endpoint.private && (
-        <DocCalloutBase calloutType="warning" title="Warning: Experimental API">
-          <p>
-            Please note that this API method is marked as unstable and should be avoided in
-            production environments. Changes may occur at any time without warning, potentially
-            impacting your scripts. We recommend contacting{' '}
-            <a href="/support?topics=technical-support">our Support Team</a> to explore alternative
-            approaches that are safer and more reliable!
-          </p>
-        </DocCalloutBase>
-      )
-    }
+    <DashboardExperimentalAPIWarning />
 
     <Prose>
       {

--- a/src/pages/docs/dashboard-api/resources/[entitySlug]/index.astro
+++ b/src/pages/docs/dashboard-api/resources/[entitySlug]/index.astro
@@ -25,6 +25,7 @@ import {
   seoShareTitle,
 } from '~/lib/datocms/seo';
 import { markdownToPlainText } from '~/components/Markdown/utils';
+import DashboardExperimentalAPIWarning from '../../components/_DashboardExperimentalAPIWarning.astro';
 
 const sidebarItems = await buildDashboardSidebarItems(Astro, Astro.params.entitySlug!);
 const resource = await findDashboardEntity(Astro, Astro.params.entitySlug!);
@@ -88,6 +89,8 @@ const plainDescription = resource.description
     <Fragment slot="title">{resource.title}</Fragment>
 
     <Prose>
+      <DashboardExperimentalAPIWarning />
+
       {resource.description && <Markdown of={resource.description} />}
 
       {


### PR DESCRIPTION
Add a warning to the dashboard API pages:

<img width="1768" height="1326" alt="Retrieve an invitation — Organization invitation — Dashboard API — DatoCMS - 2025-11-25 02-02-16 PM" src="https://github.com/user-attachments/assets/9c23fbde-4fbe-4f92-b624-1405206b9608" />
