### PR TITLE
`<ExampleComponent/>`: Use HTML details accordion instead of custom JS button

### DIFF
--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,9 +1,30 @@
 import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { defineEcConfig } from 'astro-expressive-code';
 
+/** Adds `translate="no"` and `class="notranslate"` to <code> elements
+ *  to prevent Google & Translate from breaking code block layout */
+function pluginNoTranslate() {
+  return {
+    name: 'no-translate',
+    hooks: {
+      postprocessRenderedBlock: ({ renderData }) => {
+        addNoTranslate(renderData.blockAst);
+      },
+    },
+  };
+}
+
+function addNoTranslate(node) {
+  if (node.type === 'element' && node.tagName === 'code') {
+    node.properties.translate = 'no';
+    node.properties.className = [...(node.properties.className || []), 'notranslate'];
+  }
+  node.children?.forEach(addNoTranslate);
+}
+
 export default defineEcConfig({
   themes: ['catppuccin-latte', 'catppuccin-frappe'],
-  plugins: [pluginLineNumbers()],
+  plugins: [pluginLineNumbers(), pluginNoTranslate()],
   styleOverrides: {
     codeFontSize: '1em',
     codeFontFamily: 'var(--font-mono)',

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,8 +1,9 @@
-import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { defineEcConfig } from 'astro-expressive-code';
 
-/** Adds `translate="no"` and `class="notranslate"` to <code> elements
- *  to prevent Google & Translate from breaking code block layout */
+/**
+ * Prevents translation services (Google, Baidu, etc.) from breaking code blocks.
+ * - Adds `translate="no"` and `class="notranslate"` to <code> elements
+ */
 function pluginNoTranslate() {
   return {
     name: 'no-translate',
@@ -24,7 +25,7 @@ function addNoTranslate(node) {
 
 export default defineEcConfig({
   themes: ['catppuccin-latte', 'catppuccin-frappe'],
-  plugins: [pluginLineNumbers(), pluginNoTranslate()],
+  plugins: [pluginNoTranslate()],
   styleOverrides: {
     codeFontSize: '1em',
     codeFontFamily: 'var(--font-mono)',

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,9 +1,8 @@
+import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { defineEcConfig } from 'astro-expressive-code';
 
-/**
- * Prevents translation services (Google, Baidu, etc.) from breaking code blocks.
- * - Adds `translate="no"` and `class="notranslate"` to <code> elements
- */
+/** Adds `translate="no"` and `class="notranslate"` to <code> elements
+ *  to prevent Google & Translate from breaking code block layout */
 function pluginNoTranslate() {
   return {
     name: 'no-translate',
@@ -25,7 +24,7 @@ function addNoTranslate(node) {
 
 export default defineEcConfig({
   themes: ['catppuccin-latte', 'catppuccin-frappe'],
-  plugins: [pluginNoTranslate()],
+  plugins: [pluginLineNumbers(), pluginNoTranslate()],
   styleOverrides: {
     codeFontSize: '1em',
     codeFontFamily: 'var(--font-mono)',

--- a/src/components/Code/Component.astro
+++ b/src/components/Code/Component.astro
@@ -12,27 +12,25 @@ type Props = {
 const { theme, code, language, highlightLines, showLineNumbers } = Astro.props;
 ---
 
-<div translate="no" class="notranslate">
-  {
-    theme ? (
-      <set-fancy-data-theme data-theme={theme}>
-        <Code
-          code={code}
-          lang={language}
-          mark={highlightLines?.map((line) => line + 1)}
-          showLineNumbers={showLineNumbers}
-        />
-      </set-fancy-data-theme>
-    ) : (
+{
+  theme ? (
+    <set-fancy-data-theme data-theme={theme}>
       <Code
         code={code}
         lang={language}
         mark={highlightLines?.map((line) => line + 1)}
         showLineNumbers={showLineNumbers}
       />
-    )
-  }
-</div>
+    </set-fancy-data-theme>
+  ) : (
+    <Code
+      code={code}
+      lang={language}
+      mark={highlightLines?.map((line) => line + 1)}
+      showLineNumbers={showLineNumbers}
+    />
+  )
+}
 
 <script>
   import { WebComponent } from '~/lib/WebComponent';

--- a/src/components/Code/Component.astro
+++ b/src/components/Code/Component.astro
@@ -15,20 +15,10 @@ const { theme, code, language, highlightLines, showLineNumbers } = Astro.props;
 {
   theme ? (
     <set-fancy-data-theme data-theme={theme}>
-      <Code
-        code={code}
-        lang={language}
-        mark={highlightLines?.map((line) => line + 1)}
-        showLineNumbers={showLineNumbers}
-      />
+      <Code code={code} lang={language} mark={highlightLines?.map((line) => line + 1)} />
     </set-fancy-data-theme>
   ) : (
-    <Code
-      code={code}
-      lang={language}
-      mark={highlightLines?.map((line) => line + 1)}
-      showLineNumbers={showLineNumbers}
-    />
+    <Code code={code} lang={language} mark={highlightLines?.map((line) => line + 1)} />
   )
 }
 

--- a/src/components/Code/Component.astro
+++ b/src/components/Code/Component.astro
@@ -12,25 +12,27 @@ type Props = {
 const { theme, code, language, highlightLines, showLineNumbers } = Astro.props;
 ---
 
-{
-  theme ? (
-    <set-fancy-data-theme data-theme={theme}>
+<div translate="no" class="notranslate">
+  {
+    theme ? (
+      <set-fancy-data-theme data-theme={theme}>
+        <Code
+          code={code}
+          lang={language}
+          mark={highlightLines?.map((line) => line + 1)}
+          showLineNumbers={showLineNumbers}
+        />
+      </set-fancy-data-theme>
+    ) : (
       <Code
         code={code}
         lang={language}
         mark={highlightLines?.map((line) => line + 1)}
         showLineNumbers={showLineNumbers}
       />
-    </set-fancy-data-theme>
-  ) : (
-    <Code
-      code={code}
-      lang={language}
-      mark={highlightLines?.map((line) => line + 1)}
-      showLineNumbers={showLineNumbers}
-    />
-  )
-}
+    )
+  }
+</div>
 
 <script>
   import { WebComponent } from '~/lib/WebComponent';

--- a/src/components/Code/Component.astro
+++ b/src/components/Code/Component.astro
@@ -15,10 +15,20 @@ const { theme, code, language, highlightLines, showLineNumbers } = Astro.props;
 {
   theme ? (
     <set-fancy-data-theme data-theme={theme}>
-      <Code code={code} lang={language} mark={highlightLines?.map((line) => line + 1)} />
+      <Code
+        code={code}
+        lang={language}
+        mark={highlightLines?.map((line) => line + 1)}
+        showLineNumbers={showLineNumbers}
+      />
     </set-fancy-data-theme>
   ) : (
-    <Code code={code} lang={language} mark={highlightLines?.map((line) => line + 1)} />
+    <Code
+      code={code}
+      lang={language}
+      mark={highlightLines?.map((line) => line + 1)}
+      showLineNumbers={showLineNumbers}
+    />
   )
 }
 

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -18,6 +18,27 @@ type Props = {
 const { id, title, description, tabs, startVisible } = Astro.props;
 ---
 
+<style is:global>
+  /* CSS fix for Google Translate spacing... don't remove without asking Roger!
+  See https://3.basecamp.com/5656352/buckets/33592490/card_tables/cards/9712869637
+  */
+
+  html.translated-ltr .expressive-code code {
+    white-space-collapse: collapse !important;
+    div.ec-line {
+      white-space-collapse: preserve-spaces !important;
+      div.code {
+        margin-left: -180px !important;
+      }
+    }
+  }
+
+  /* Ask Stefano about this; not sure why this is needed */
+  endpoint-example {
+    display: contents;
+  }
+</style>
+
 <prose-island>
   <endpoint-example slug={id}>
     <details class={s.reqRes} open={startVisible}>
@@ -102,9 +123,3 @@ const { id, title, description, tabs, startVisible } = Astro.props;
     },
   );
 </script>
-
-<style>
-  endpoint-example {
-    display: contents;
-  }
-</style>

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -5,6 +5,7 @@ import { Markdown } from '~/components/Markdown';
 import { Tab, Tabs } from '~/components/Tabs';
 import { Code } from '~/components/Code';
 import { Prose } from '~/components/Prose';
+import { stripStega } from '@datocms/astro';
 
 type Props = {
   id: string;
@@ -29,7 +30,7 @@ const { id, title, description, tabs, startVisible } = Astro.props;
         {
           description && (
             <Prose class={s.description}>
-              <Markdown of={description} />
+              <Markdown of={stripStega(description)} />
             </Prose>
           )
         }
@@ -38,17 +39,20 @@ const { id, title, description, tabs, startVisible } = Astro.props;
           tabs.length > 1 ? (
             <div class={s.tabs}>
               <Tabs>
-                {tabs.map((tab) => (
-                  <Tab title={tab.title} noPadding>
-                    {tab.description && (
-                      <div class={s.description}>
-                        <Markdown of={tab.description} />
-                      </div>
-                    )}
+                {tabs.map((rawTab) => {
+                  const tab = stripStega(rawTab);
+                  return (
+                    <Tab title={tab.title} noPadding>
+                      {tab.description && (
+                        <div class={s.description}>
+                          <Markdown of={tab.description} />
+                        </div>
+                      )}
 
-                    <Code code={tab.code} language={tab.language} />
-                  </Tab>
-                ))}
+                      <Code code={tab.code} language={tab.language} />
+                    </Tab>
+                  );
+                })}
               </Tabs>
             </div>
           ) : (

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -23,12 +23,19 @@ const { id, title, description, tabs, startVisible } = Astro.props;
   See https://3.basecamp.com/5656352/buckets/33592490/card_tables/cards/9712869637
   */
 
-  html.translated-ltr .expressive-code code {
-    white-space-collapse: collapse !important;
-    div.ec-line {
-      white-space-collapse: preserve-spaces !important;
-      div.code {
-        margin-left: -180px !important;
+  /* Only active when the HTML has .translated-ltr/rtl appended by Google */
+  html.translated-ltr,
+  html.translated-rtl {
+    .expressive-code code {
+      white-space-collapse: collapse !important;
+      div.ec-line {
+        white-space-collapse: preserve-spaces !important;
+        div.gutter {
+          display: none; /* We have to hide line numbesr or it interferes with the hack */
+        }
+        div.code {
+          margin-left: -180px !important;
+        }
       }
     }
   }

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -59,11 +59,11 @@ const { id, title, description, tabs, startVisible } = Astro.props;
             <>
               {tabs[0]!.description && (
                 <div class={s.description}>
-                  <Markdown of={tabs[0]!.description} />
+                  <Markdown of={stripStega(tabs[0]!.description)} />
                 </div>
               )}
 
-              <Code code={tabs[0]!.code} language={tabs[0]!.language} />
+              <Code code={stripStega(tabs[0]!.code)} language={stripStega(tabs[0]!.language)} />
             </>
           )
         }

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -31,7 +31,7 @@ const { id, title, description, tabs, startVisible } = Astro.props;
       div.ec-line {
         white-space-collapse: preserve-spaces !important;
         div.gutter {
-          display: none; /* We have to hide line numbesr or it interferes with the hack */
+          display: none !important; /* We have to hide line numbesr or it interferes with the hack */
         }
         div.code {
           margin-left: -180px !important;

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -59,11 +59,11 @@ const { id, title, description, tabs, startVisible } = Astro.props;
             <>
               {tabs[0]!.description && (
                 <div class={s.description}>
-                  <Markdown of={stripStega(tabs[0]!.description)} />
+                  <Markdown of={tabs[0]!.description} />
                 </div>
               )}
 
-              <Code code={stripStega(tabs[0]!.code)} language={stripStega(tabs[0]!.language)} />
+              <Code code={tabs[0]!.code} language={tabs[0]!.language} />
             </>
           )
         }

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -1,7 +1,6 @@
 ---
 import { Heading } from '~/components/Heading';
 import s from './style.module.css';
-import { TargetToggler } from '~/components/TargetToggler';
 import { Markdown } from '~/components/Markdown';
 import { Tab, Tabs } from '~/components/Tabs';
 import { Code } from '~/components/Code';
@@ -20,15 +19,13 @@ const { id, title, description, tabs, startVisible } = Astro.props;
 
 <prose-island>
   <endpoint-example slug={id}>
-    <div class={s.reqRes}>
-      <TargetToggler targetId={`example-${id}`} startVisible={startVisible}>
-        <Heading as="button" class={s.title} anchor={id}>
-          <span class={s.pill}>Example</span>{' '}
-          <span class={s.titleTitle}>{title}</span>
-        </Heading>
-      </TargetToggler>
+    <details class={s.reqRes} open={startVisible}>
+      <Heading as="summary" class={s.title} anchor={id}>
+        <span class={s.pill}>Example</span>{' '}
+        <span class={s.titleTitle}>{title}</span>
+      </Heading>
 
-      <div id={`example-${id}`} class={s.details}>
+      <div class={s.details}>
         {
           description && (
             <Prose class={s.description}>
@@ -67,7 +64,7 @@ const { id, title, description, tabs, startVisible } = Astro.props;
           )
         }
       </div>
-    </div>
+    </details>
   </endpoint-example>
 </prose-island>
 
@@ -77,8 +74,6 @@ const { id, title, description, tabs, startVisible } = Astro.props;
   window.customElements.define(
     'endpoint-example',
     class EndpointExample extends WebComponent {
-      toggler!: HTMLButtonElement;
-
       parsedCallback() {
         this.handleHashChange();
         window.addEventListener('hashchange', this.handleHashChange);
@@ -91,13 +86,13 @@ const { id, title, description, tabs, startVisible } = Astro.props;
       }
 
       handleHashChange = (): void => {
-        this.toggler = this.$('target-toggler');
+        const details = this.$('details') as HTMLDetailsElement;
 
         const currentHash = window.location.hash.slice(1);
         const slug = this.getAttribute('slug');
 
         if (currentHash === slug) {
-          (this.toggler as any).toggle(true);
+          details.open = true;
         }
       };
     },

--- a/src/components/docs/restApi/EndpointExample/Component.astro
+++ b/src/components/docs/restApi/EndpointExample/Component.astro
@@ -21,20 +21,26 @@ const { id, title, description, tabs, startVisible } = Astro.props;
 <style is:global>
   /* CSS fix for Google Translate spacing... don't remove without asking Roger!
   See https://3.basecamp.com/5656352/buckets/33592490/card_tables/cards/9712869637
+  Only active when the HTML has .translated-ltr/rtl appended by Google
   */
-
-  /* Only active when the HTML has .translated-ltr/rtl appended by Google */
   html.translated-ltr,
   html.translated-rtl {
     .expressive-code code {
-      white-space-collapse: collapse !important;
-      div.ec-line {
-        white-space-collapse: preserve-spaces !important;
-        div.gutter {
-          display: none !important; /* We have to hide line numbesr or it interferes with the hack */
-        }
-        div.code {
-          margin-left: -180px !important;
+      white-space-collapse: collapse !important; /* Google was adding extra whitespace */
+
+      div.gutter {
+        display: none !important; /* We have to hide line numbers or it interferes with the hack */
+      }
+
+      /* Only Firefox supports preserve-spaces so we can make it look slightly better there
+      https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/white-space-collapse#browser_compatibility
+      */
+      @supports (white-space-collapse: preserve-spaces) {
+        div.ec-line {
+          white-space-collapse: preserve-spaces !important;
+          div.code {
+            margin-left: -180px !important;
+          }
         }
       }
     }

--- a/src/components/docs/restApi/EndpointExample/style.module.css
+++ b/src/components/docs/restApi/EndpointExample/style.module.css
@@ -34,6 +34,7 @@
   line-height: normal;
   text-align: inherit;
   display: block;
+  list-style: none;
 
   font-size: 120%;
   font-weight: bold;
@@ -53,11 +54,6 @@
 
 .details {
   margin-top: 20px;
-  display: none;
-
-  &[data-open] {
-    display: block;
-  }
 }
 
 .tabs {


### PR DESCRIPTION
Our previous use of custom JS buttons for the example accordions were breaking translation services like Google Translate or Baidu Translate.

I'm HOPING using standard HTML components lets them read this more easily, but I'm not sure...