### PR TITLE
SEO title improvements

### DIFF
--- a/src/layouts/BaseLayout/Component.astro
+++ b/src/layouts/BaseLayout/Component.astro
@@ -1,10 +1,11 @@
 ---
-import { ContentLink, Seo, type TitleMetaLinkTag } from '@datocms/astro';
+import { ContentLink, Seo, stripStega, type TitleMetaLinkTag } from '@datocms/astro';
 import { ClientRouter } from 'astro:transitions';
 import './global.css';
 import ProgressBar from './_ProgressBar.astro';
 import { fetchFavicon } from './fetchFavicon';
 import { isDraftModeEnabled } from '~/lib/draftMode';
+import { overrideSeo, replaceSeoPageTitleSuffix } from '~/lib/datocms/seo';
 
 type Props = {
   seo: TitleMetaLinkTag[];
@@ -14,6 +15,28 @@ const { seo } = Astro.props;
 
 const result = await fetchFavicon(Astro);
 const draftModeEnabled = isDraftModeEnabled(Astro);
+
+// Maps route prefixes to section-specific title suffixes. Top-level pages
+// (e.g. `/blog` itself) are excluded so that titles like "DatoCMS Blog — DatoCMS Blog"
+// are avoided.
+const titleSuffixByPathPrefix: [string, string][] = [
+  ['/docs', 'DatoCMS Docs'],
+  ['/academy', 'DatoCMS Academy'],
+  ['/user-guides', 'DatoCMS User Guides'],
+  ['/product-updates', 'DatoCMS Product Updates'],
+  ['/blog', 'DatoCMS Blog'],
+];
+
+function titleSuffixForPath(pathname: string): string | undefined {
+  const normalized = pathname.replace(/\/+$/, '');
+
+  return titleSuffixByPathPrefix.find(
+    ([prefix]) => normalized.startsWith(prefix) && normalized !== prefix,
+  )?.[1];
+}
+
+const suffix = titleSuffixForPath(Astro.url.pathname);
+const finalSeo = suffix ? overrideSeo(seo, replaceSeoPageTitleSuffix(suffix)) : seo;
 ---
 
 <!doctype html>
@@ -25,7 +48,9 @@ const draftModeEnabled = isDraftModeEnabled(Astro);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <Seo data={[...result._site.faviconMetaTags, ...seo]} />
+    <!-- Strip stega (content-link annotation) characters from head meta tags so
+         that invisible markers don't inflate the <title> length in draft mode -->
+    <Seo data={stripStega([...result._site.faviconMetaTags, ...finalSeo])} />
     <link rel="alternate" type="application/rss+xml" title="DatoCMS Blog" href="/blog.xml" />
     <link
       rel="alternate"

--- a/src/layouts/docs/PageLayout/Component.astro
+++ b/src/layouts/docs/PageLayout/Component.astro
@@ -6,7 +6,7 @@ import { Image } from '~/components/blocks/Image';
 import { InternalVideo } from '~/components/blocks/InternalVideo';
 import { CloneButtonForm } from '~/components/docs/blocks/CloneButtonForm';
 import { Demo } from '~/components/blocks/Demo';
-import { overrideSeo, seoGeneratedCard, prependToSeoPageTitle } from '~/lib/datocms/seo';
+import { overrideSeo, seoGeneratedCard, prependToSeoPageTitleIfMissing } from '~/lib/datocms/seo';
 import { JsonLd } from '~/components/JsonLd';
 import { baseUrl } from '~/lib/draftMode';
 import { DeployButtonForm } from '~/components/docs/blocks/DeployButtonForm';
@@ -70,7 +70,7 @@ const tocGroups = [
   group={maskedGroup}
   seo={overrideSeo(
     page._seoMetaTags,
-    prependToSeoPageTitle(group.pagesOrSections.length > 1 ? `${group.name}: ` : ''),
+    prependToSeoPageTitleIfMissing(group.pagesOrSections.length > 1 ? `${group.name}: ` : ''),
     seoGeneratedCard(Astro, {
       kicker: group ? `Documentation: ${group.name}` : 'DatoCMS Docs',
       title: page.title,

--- a/src/lib/datocms/seo.ts
+++ b/src/lib/datocms/seo.ts
@@ -1,3 +1,4 @@
+import type { TitleMetaLinkTag } from '@datocms/astro';
 import type { AstroGlobal } from 'astro';
 import { truncate, without } from 'lodash-es';
 import { isDefined } from '../isDefined';
@@ -5,16 +6,27 @@ import { ogCardUrl, type OgCardData } from '../ogCardUrl';
 
 const pageTitleSuffix = 'DatoCMS';
 
-type SeoMetaTag = {
-  tag: string;
-  attributes: Record<string, string> | null;
-  content: string | null;
-};
+/**
+ * SEO operation that replaces the default `" — DatoCMS"` title suffix with a
+ * custom one. Only modifies the `<title>` tag; other meta tags are unchanged.
+ */
+export function replaceSeoPageTitleSuffix(newSuffix: string) {
+  return (tags: TitleMetaLinkTag[]) =>
+    tags.map((tag) => {
+      if (tag.tag === 'title' && tag.content) {
+        return {
+          ...tag,
+          content: tag.content.replace(new RegExp(` — ${pageTitleSuffix}$`), ` — ${newSuffix}`),
+        };
+      }
+      return tag;
+    });
+}
 
-type Operation = (tags: SeoMetaTag[]) => SeoMetaTag[];
+type Operation = (tags: TitleMetaLinkTag[]) => TitleMetaLinkTag[];
 
 export function overrideSeo(
-  tags: SeoMetaTag[],
+  tags: TitleMetaLinkTag[],
   ...operations: Array<Operation | Operation[] | undefined | null | false>
 ) {
   return [baseMetas(), ...operations]
@@ -33,7 +45,7 @@ function baseMetas() {
 }
 
 export function seoPageTitle(...chunks: string[]) {
-  return (tags: SeoMetaTag[]) => [
+  return (tags: TitleMetaLinkTag[]) => [
     ...tags.filter((tag) => tag.tag !== 'title'),
     {
       tag: 'title',
@@ -43,15 +55,50 @@ export function seoPageTitle(...chunks: string[]) {
   ];
 }
 
-export function prependToSeoPageTitle(...chunks: string[]) {
-  return (tags: SeoMetaTag[]) => {
+/**
+ * Prepends chunks to the existing `<title>`, dropping any chunk that already
+ * appears in the title (case-insensitive, punctuation-insensitive, word-bounded).
+ *
+ * - original title: "Setup — DatoCMS"
+ *   prepend:        "Guide: "
+ *   result:         "Guide: Setup — DatoCMS"
+ *
+ * - original title: "NextJS Overview — DatoCMS"
+ *   prepend:        "Next.js: "
+ *   result:         "NextJS Overview — DatoCMS"   (chunk dropped: "Next.js" ≈ "NextJS")
+ *
+ * - original title: "Reactive Patterns — DatoCMS"
+ *   prepend:        "React: "
+ *   result:         "React: Reactive Patterns — DatoCMS"   (chunk kept: word boundary)
+ */
+export function prependToSeoPageTitleIfMissing(...chunks: string[]) {
+  const normalizeForComparison = (str: string) =>
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, '')
+      .replace(/\s+/g, ' ');
+
+  return (tags: TitleMetaLinkTag[]) => {
     const title = tags.find((tag) => tag.tag === 'title')!;
+    const normalizedTitle = normalizeForComparison(title.content ?? '');
+
+    const filteredChunks = chunks.filter((chunk) => {
+      const normalized = normalizeForComparison(chunk);
+      if (!normalized) return false;
+
+      // Check whether the chunk already appears as a full word/phrase in the title
+      return !new RegExp(`\\b${normalized}\\b`).test(normalizedTitle);
+    });
+
+    if (filteredChunks.length === 0) {
+      return tags;
+    }
 
     return [
       ...without(tags, title),
       {
         tag: 'title',
-        content: [...chunks, title.content].join(''),
+        content: [...filteredChunks, title.content].join(''),
         attributes: {},
       },
     ];
@@ -59,7 +106,7 @@ export function prependToSeoPageTitle(...chunks: string[]) {
 }
 
 function seoMeta(propertyOrName: string, newValue: string) {
-  return (tags: SeoMetaTag[]) => [
+  return (tags: TitleMetaLinkTag[]) => [
     ...tags.filter(
       (tag) =>
         tag.attributes?.property !== propertyOrName && tag.attributes?.name !== propertyOrName,
@@ -71,7 +118,7 @@ function seoMeta(propertyOrName: string, newValue: string) {
         content: newValue,
       },
       content: null,
-    } as SeoMetaTag,
+    } as TitleMetaLinkTag,
   ];
 }
 
@@ -114,7 +161,7 @@ export function seoTwitterCard(type: 'summary' | 'summary_large_image') {
   return seoMeta('twitter:card', type);
 }
 
-export function extractFromSeoTags(tags: SeoMetaTag[]) {
+export function extractFromSeoTags(tags: TitleMetaLinkTag[]) {
   const findAttr = (key: string) =>
     tags.find((t) => t.attributes?.name === key || t.attributes?.property === key)?.attributes
       ?.content;


### PR DESCRIPTION
- Adds category suffix (e.g. DatoCMS Docs, DatoCMS Academy, DatoCMS Product Updates, etc.)
- Adds prefix de-duplication (no more "Next.js - Next.js + DatoCMS Overview)
- Fixes preview mode titles being cropped by Visual Editing steganography

## Examples

* [Next.js: Next.js + DatoCMS Overview - DatoCMS](https://www.datocms.com/docs/next-js) --> [Next.js + DatoCMS Overview - DatoCMS Docs](https://www.staging-datocms.com/docs/next-js)
* [Introducing Visual Editing - DatoCMS](https://www.datocms.com/product-updates/introducing-visual-editing) --> [Introducing Visual Editing - DatoCMS Product Updates](https://www.staging-datocms.com/product-updates/introducing-visual-editing)
* [[Introducing Visual Editing for Headless CMS - DatoCMS]](https://www.datocms.com/blog/introducing-visual-editing) --> [Introducing Visual Editing for Headless CMS - DatoCMS Blog](https://www.staging-datocms.com/blog/introducing-visual-editing)