### PR TITLE
Pin skill archive downloads before package migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "serve": "dotenv -e .env.production -c -- bash -c 'node ./dist/server/entry.mjs'",
     "start-prod": "npm run astro build && npm run serve",
     "check:agent-skills": "node scripts/check-agent-skills.mjs",
-    "test:agent-skills": "node --test scripts/check-agent-skills.test.mjs"
+    "test:agent-skills": "vitest run scripts/check-agent-skills.test.mjs"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "format": "npx prettier . --write",
     "test": "vitest",
     "serve": "dotenv -e .env.production -c -- bash -c 'node ./dist/server/entry.mjs'",
-    "start-prod": "npm run astro build && npm run serve"
+    "start-prod": "npm run astro build && npm run serve",
+    "check:agent-skills": "node scripts/check-agent-skills.mjs",
+    "test:agent-skills": "node --test scripts/check-agent-skills.test.mjs"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",

--- a/scripts/check-agent-skills.mjs
+++ b/scripts/check-agent-skills.mjs
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const archiveUrl =
+  /^https:\/\/raw\.githubusercontent\.com\/datocms\/agent-skills\/([a-f0-9]{40})\/zips\/(datocms(?:-[a-z0-9]+)*)\.zip$/;
+
+export async function checkAgentSkills(index, fetchArchive = fetch) {
+  if (!Array.isArray(index.skills) || index.skills.length === 0) {
+    throw new Error('The skill index must contain at least one archive.');
+  }
+  const names = new Set();
+  let revision;
+  for (const entry of index.skills) {
+    const match = typeof entry.url === 'string' && entry.url.match(archiveUrl);
+    if (!match || entry.type !== 'archive' || match[2] !== entry.name) {
+      throw new Error(`Invalid or unpinned archive URL for ${entry.name}.`);
+    }
+    if (names.has(entry.name)) throw new Error(`Duplicate skill: ${entry.name}.`);
+    names.add(entry.name);
+    if (revision && revision !== match[1]) {
+      throw new Error('All skill archives must use the same immutable revision.');
+    }
+    revision = match[1];
+    if (!/^sha256:[a-f0-9]{64}$/.test(entry.digest || '')) {
+      throw new Error(`Invalid digest for ${entry.name}.`);
+    }
+    const response = await fetchArchive(entry.url, {
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Cannot fetch ${entry.name}: HTTP ${response.status}.`);
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    const digest = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+    if (digest !== entry.digest) {
+      throw new Error(`Archive digest mismatch for ${entry.name}.`);
+    }
+  }
+  return { count: names.size, revision };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const index = JSON.parse(
+      await readFile(
+        new URL('../src/documents/well-known/agent-skills/index.json', import.meta.url),
+        'utf8',
+      ),
+    );
+    const { count, revision } = await checkAgentSkills(index);
+    console.log(`Verified ${count} skill archive(s) at ${revision}.`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-agent-skills.test.mjs
+++ b/scripts/check-agent-skills.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { test } from 'node:test';
+import { test } from 'vitest';
 import { checkAgentSkills } from './check-agent-skills.mjs';
 
 const revision = '86c533b74c2913e590797eb0b2622d2cdfe5cf68';

--- a/scripts/check-agent-skills.test.mjs
+++ b/scripts/check-agent-skills.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+import { checkAgentSkills } from './check-agent-skills.mjs';
+
+const revision = '86c533b74c2913e590797eb0b2622d2cdfe5cf68';
+const bytes = Buffer.from('fixture archive bytes');
+function entry(name = 'datocms-cma') {
+  return {
+    name,
+    type: 'archive',
+    url: `https://raw.githubusercontent.com/datocms/agent-skills/${revision}/zips/${name}.zip`,
+    digest: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+  };
+}
+const ok = async () => new Response(bytes);
+
+test('checks the digest of the bytes fetched from the pinned URL', async () => {
+  const archive = entry();
+  const seen = [];
+  const result = await checkAgentSkills({ skills: [archive] }, async (url) => {
+    seen.push(url);
+    return new Response(bytes);
+  });
+  assert.deepEqual(seen, [archive.url]);
+  assert.deepEqual(result, { count: 1, revision });
+});
+
+test('rejects mutable URLs before requesting an archive', async () => {
+  const archive = entry();
+  archive.url = archive.url.replace(revision, 'master');
+  await assert.rejects(
+    checkAgentSkills({ skills: [archive] }, () => {
+      assert.fail('must validate the URL before fetching');
+    }),
+    /unpinned/,
+  );
+});
+
+test('rejects a mismatched digest', async () => {
+  await assert.rejects(
+    checkAgentSkills({ skills: [entry()] }, async () => new Response('different archive bytes')),
+    /digest mismatch/,
+  );
+});
+
+test('rejects failed downloads', async () => {
+  await assert.rejects(
+    checkAgentSkills({ skills: [entry()] }, async () => new Response('', { status: 404 })),
+    /HTTP 404/,
+  );
+});
+
+test('rejects empty and duplicate catalogs', async () => {
+  await assert.rejects(checkAgentSkills({ skills: [] }, ok), /at least one/);
+  await assert.rejects(checkAgentSkills({ skills: [entry(), entry()] }, ok), /Duplicate/);
+});
+
+test('rejects mismatched archive names and mixed revisions', async () => {
+  const mismatched = { ...entry(), name: 'datocms-cli' };
+  await assert.rejects(checkAgentSkills({ skills: [mismatched] }, ok), /Invalid/);
+  const another = entry('datocms-cli');
+  another.url = another.url.replace(revision, 'a'.repeat(40));
+  await assert.rejects(checkAgentSkills({ skills: [entry(), another] }, ok), /same immutable/);
+});

--- a/src/documents/well-known/agent-skills/index.json
+++ b/src/documents/well-known/agent-skills/index.json
@@ -5,57 +5,57 @@
       "name": "datocms-cda",
       "type": "archive",
       "description": "Query the DatoCMS Content Delivery API (CDA) — the read-only GraphQL API — using @datocms/cda-client. Use when users ask for GraphQL content reads: fetching posts/pages/projects, filtering by date/text/fields, sorting/order, pagination, localization, modular content, Structured Text, responsive images, SEO metadata.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-cda.zip",
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cda.zip",
       "digest": "sha256:81d973e26d9f2fe4854cdf74c06f8e14154828d46e5a0490669a4079e60162f1"
     },
     {
       "name": "datocms-cli",
       "type": "archive",
       "description": "DatoCMS CLI (datocms) — command-line migrations, schema codegen, schema inspection, typed CMA scripts, environment operations, deployment workflows, and multi-project profile syncing.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-cli.zip",
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cli.zip",
       "digest": "sha256:7e63b3d3becfa8ed4c398c50fe3edba66f5caec629ccfa82b91af80e59acbc53"
     },
     {
       "name": "datocms-cma",
       "type": "archive",
       "description": "Node.js/TypeScript scripts driving the DatoCMS Content Management API via @datocms/cma-client. Covers content ops (CRUD, bulk import/export, CSV pipelines, asset uploads), environment management (forks, promotions, webhooks), and role/token administration.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-cma.zip",
-      "digest": "sha256:291b0dad044b8ca35aa87a7b252c033179adadeebb312ee9bc24e4ad153a6ac6"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cma.zip",
+      "digest": "sha256:901224cc662449d4442a0437b5ca1183676ebb2bf7503719049faef01c8c7748"
     },
     {
       "name": "datocms-content-modeling",
       "type": "archive",
       "description": "Decision frameworks for DatoCMS content modeling — schema shape, field choice, content reuse, taxonomies, content vs presentation, and admin UI organization. Use for modeling decisions: model vs block, single_block vs Modular Content vs Structured Text, references vs embedded blocks, taxonomy shape.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-content-modeling.zip",
-      "digest": "sha256:cb2d841f2046770c93824affe2a8c977407c8e687c127d5630a2b2bd082b60cd"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-content-modeling.zip",
+      "digest": "sha256:5ff3036631ceea4d8de7b870e823582b57a1643f94baed13d28faea959fde829"
     },
     {
       "name": "datocms-feedback",
       "type": "archive",
       "description": "Draft sanitized feedback emails to support@datocms.com about frustrating DatoCMS skills or MCP experiences. Use only when users explicitly ask to report, email, or summarize feedback about DatoCMS skills/MCP.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-feedback.zip",
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-feedback.zip",
       "digest": "sha256:95d165831da274506605bed1496528355d266e9862798ed22200283179103b4f"
     },
     {
       "name": "datocms-frontend-integrations",
       "type": "archive",
       "description": "Patch, extend, or explain DatoCMS front-end integration code in existing web projects (Next.js App Router, Nuxt, SvelteKit, Astro, plus React/Vue/Svelte components). Covers draft mode endpoints, Preview Links, Visual Editing, Content Link overlays, real-time preview subscriptions, cache-tag invalidation, and crawler-safe SEO wiring.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-frontend-integrations.zip",
-      "digest": "sha256:ab5c8398e71563af8ac90b22861a5b2af124370162784b3fbc14b4549a70f3d3"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-frontend-integrations.zip",
+      "digest": "sha256:047ec255203340d35ee0a5b892a200ad63cba0bc7c47b11031283f7b3fea3b4d"
     },
     {
       "name": "datocms-plugin",
       "type": "archive",
       "description": "Build, scaffold, maintain, or restyle DatoCMS plugins built with datocms-plugin-sdk and datocms-react-ui. Covers plugin hooks, field extensions, config screens, sidebars, pages, modals, asset sources, dropdown actions, lifecycle hooks, and dark mode.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-plugin.zip",
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-plugin.zip",
       "digest": "sha256:09da36b71369409000fe8a35900cf4bbe03988fba4e244e724e68bf50781a472"
     },
     {
       "name": "datocms-setup",
       "type": "archive",
       "description": "Single entry point for one-shot, end-to-end DatoCMS project setup — bundles prerequisites, chains recipes, takes a greenfield or partial project to working state in one pass. Covers frontend foundation (Next.js/Nuxt/SvelteKit/Astro), frontend features (draft mode, visual editing, real-time updates, SEO), migrations, and CI/CD wiring.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/master/zips/datocms-setup.zip",
-      "digest": "sha256:361ce78592bb0ee32831772b669e76d11ae69c4f004fc5a4115963b91f146b3b"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-setup.zip",
+      "digest": "sha256:5eb5f7f555475c9d2df7b3e45b1779e8b338170588ae471e07d57f9c5dc32d75"
     }
   ]
 }


### PR DESCRIPTION
The skill discovery catalog references mutable archives, and four recorded digests no longer match those files. Pin all eight downloads to the retained pre-migration revision and calculate their digests from the exact archive bytes.

This preparation must be deployed before the unified package removes the old archive paths. It preserves the existing catalog while the migration is reviewed separately. The checker tests and focused test command use Vitest, matching the repository's existing test runner.

Validation on Node 22: all 23 tests, six focused checker tests, full formatting check, Astro check, build, and diff checks pass. All eight pinned downloads were fetched and their SHA-256 digests verified. Includes reusable archive verification commands for later catalog updates.

Rollout: release and verify this preparation before https://github.com/datocms/agent-skills/pull/12. The unified consumer follow-up is https://github.com/datocms/astro-website/pull/119.
