### PR TITLE
Advertise the unified DatoCMS skill archive

### DIFF
--- a/scripts/check-agent-skills.mjs
+++ b/scripts/check-agent-skills.mjs
@@ -3,41 +3,30 @@ import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const archiveUrl =
-  /^https:\/\/raw\.githubusercontent\.com\/datocms\/agent-skills\/([a-f0-9]{40})\/zips\/(datocms(?:-[a-z0-9]+)*)\.zip$/;
+  /^https:\/\/raw\.githubusercontent\.com\/datocms\/agent-skills\/([a-f0-9]{40})\/zips\/datocms\.zip$/;
 
 export async function checkAgentSkills(index, fetchArchive = fetch) {
-  if (!Array.isArray(index.skills) || index.skills.length === 0) {
-    throw new Error('The skill index must contain at least one archive.');
+  if (
+    !Array.isArray(index.skills) ||
+    index.skills.length !== 1 ||
+    index.skills[0]?.name !== 'datocms'
+  ) {
+    throw new Error('The discovery index must advertise only the datocms skill.');
   }
-  const names = new Set();
-  let revision;
-  for (const entry of index.skills) {
-    const match = typeof entry.url === 'string' && entry.url.match(archiveUrl);
-    if (!match || entry.type !== 'archive' || match[2] !== entry.name) {
-      throw new Error(`Invalid or unpinned archive URL for ${entry.name}.`);
-    }
-    if (names.has(entry.name)) throw new Error(`Duplicate skill: ${entry.name}.`);
-    names.add(entry.name);
-    if (revision && revision !== match[1]) {
-      throw new Error('All skill archives must use the same immutable revision.');
-    }
-    revision = match[1];
-    if (!/^sha256:[a-f0-9]{64}$/.test(entry.digest || '')) {
-      throw new Error(`Invalid digest for ${entry.name}.`);
-    }
-    const response = await fetchArchive(entry.url, {
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!response.ok) {
-      throw new Error(`Cannot fetch ${entry.name}: HTTP ${response.status}.`);
-    }
-    const bytes = Buffer.from(await response.arrayBuffer());
-    const digest = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
-    if (digest !== entry.digest) {
-      throw new Error(`Archive digest mismatch for ${entry.name}.`);
-    }
+  const entry = index.skills[0];
+  const match = typeof entry.url === 'string' && entry.url.match(archiveUrl);
+  if (!match || entry.type !== 'archive') {
+    throw new Error('Invalid or unpinned datocms archive URL.');
   }
-  return { count: names.size, revision };
+  if (!/^sha256:[a-f0-9]{64}$/.test(entry.digest || '')) {
+    throw new Error('Invalid digest for datocms.');
+  }
+  const response = await fetchArchive(entry.url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) throw new Error(`Cannot fetch datocms: HTTP ${response.status}.`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const digest = `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+  if (digest !== entry.digest) throw new Error('Archive digest mismatch for datocms.');
+  return { count: 1, revision: match[1] };
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/check-agent-skills.test.mjs
+++ b/scripts/check-agent-skills.test.mjs
@@ -1,15 +1,16 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { test } from 'vitest';
 import { checkAgentSkills } from './check-agent-skills.mjs';
 
-const revision = '86c533b74c2913e590797eb0b2622d2cdfe5cf68';
+const revision = 'b22e0f87d52bd1a20f146191ba760ce46616150e';
 const bytes = Buffer.from('fixture archive bytes');
-function entry(name = 'datocms-cma') {
+function entry() {
   return {
-    name,
+    name: 'datocms',
     type: 'archive',
-    url: `https://raw.githubusercontent.com/datocms/agent-skills/${revision}/zips/${name}.zip`,
+    url: `https://raw.githubusercontent.com/datocms/agent-skills/${revision}/zips/datocms.zip`,
     digest: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
   };
 }
@@ -51,15 +52,35 @@ test('rejects failed downloads', async () => {
   );
 });
 
-test('rejects empty and duplicate catalogs', async () => {
-  await assert.rejects(checkAgentSkills({ skills: [] }, ok), /at least one/);
-  await assert.rejects(checkAgentSkills({ skills: [entry(), entry()] }, ok), /Duplicate/);
+test('rejects empty, duplicate, and legacy catalogs', async () => {
+  for (const skills of [[], [entry(), entry()], [{ ...entry(), name: 'datocms-cma' }]]) {
+    await assert.rejects(checkAgentSkills({ skills }, ok), /only the datocms skill/);
+  }
 });
 
-test('rejects mismatched archive names and mixed revisions', async () => {
-  const mismatched = { ...entry(), name: 'datocms-cli' };
-  await assert.rejects(checkAgentSkills({ skills: [mismatched] }, ok), /Invalid/);
-  const another = entry('datocms-cli');
-  another.url = another.url.replace(revision, 'a'.repeat(40));
-  await assert.rejects(checkAgentSkills({ skills: [entry(), another] }, ok), /same immutable/);
+test('rejects old archive names and malformed digests', async () => {
+  const legacy = {
+    ...entry(),
+    url: entry().url.replace('zips/datocms.zip', 'zips/datocms-cma.zip'),
+  };
+  await assert.rejects(checkAgentSkills({ skills: [legacy] }, ok), /Invalid/);
+  await assert.rejects(
+    checkAgentSkills({ skills: [{ ...entry(), digest: 'sha256:bad' }] }, ok),
+    /Invalid digest/,
+  );
+});
+
+test('the checked-in catalog contains one pinned unified archive', async () => {
+  const index = JSON.parse(
+    await readFile(
+      new URL('../src/documents/well-known/agent-skills/index.json', import.meta.url),
+      'utf8',
+    ),
+  );
+  assert.deepEqual(
+    index.skills.map(({ name }) => name),
+    ['datocms'],
+  );
+  assert.match(index.skills[0].url, /\/[a-f0-9]{40}\/zips\/datocms\.zip$/);
+  assert.match(index.skills[0].digest, /^sha256:[a-f0-9]{64}$/);
 });

--- a/scripts/check-agent-skills.test.mjs
+++ b/scripts/check-agent-skills.test.mjs
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { test } from 'vitest';
 import { checkAgentSkills } from './check-agent-skills.mjs';
 
-const revision = 'b22e0f87d52bd1a20f146191ba760ce46616150e';
+const revision = 'cf3d1bd2af63c95d657fa80f7c242827c689db7f';
 const bytes = Buffer.from('fixture archive bytes');
 function entry() {
   return {

--- a/scripts/check-agent-skills.test.mjs
+++ b/scripts/check-agent-skills.test.mjs
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { test } from 'vitest';
 import { checkAgentSkills } from './check-agent-skills.mjs';
 
-const revision = 'cf3d1bd2af63c95d657fa80f7c242827c689db7f';
+const revision = '85199280596f8679f4b78d6b48ea7cfa4d15b4ca';
 const bytes = Buffer.from('fixture archive bytes');
 function entry() {
   return {

--- a/src/documents/well-known/agent-skills/index.json
+++ b/src/documents/well-known/agent-skills/index.json
@@ -2,60 +2,11 @@
   "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "skills": [
     {
-      "name": "datocms-cda",
+      "name": "datocms",
       "type": "archive",
-      "description": "Query the DatoCMS Content Delivery API (CDA) — the read-only GraphQL API — using @datocms/cda-client. Use when users ask for GraphQL content reads: fetching posts/pages/projects, filtering by date/text/fields, sorting/order, pagination, localization, modular content, Structured Text, responsive images, SEO metadata.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cda.zip",
-      "digest": "sha256:81d973e26d9f2fe4854cdf74c06f8e14154828d46e5a0490669a4079e60162f1"
-    },
-    {
-      "name": "datocms-cli",
-      "type": "archive",
-      "description": "DatoCMS CLI (datocms) — command-line migrations, schema codegen, schema inspection, typed CMA scripts, environment operations, deployment workflows, and multi-project profile syncing.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cli.zip",
-      "digest": "sha256:7e63b3d3becfa8ed4c398c50fe3edba66f5caec629ccfa82b91af80e59acbc53"
-    },
-    {
-      "name": "datocms-cma",
-      "type": "archive",
-      "description": "Node.js/TypeScript scripts driving the DatoCMS Content Management API via @datocms/cma-client. Covers content ops (CRUD, bulk import/export, CSV pipelines, asset uploads), environment management (forks, promotions, webhooks), and role/token administration.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-cma.zip",
-      "digest": "sha256:901224cc662449d4442a0437b5ca1183676ebb2bf7503719049faef01c8c7748"
-    },
-    {
-      "name": "datocms-content-modeling",
-      "type": "archive",
-      "description": "Decision frameworks for DatoCMS content modeling — schema shape, field choice, content reuse, taxonomies, content vs presentation, and admin UI organization. Use for modeling decisions: model vs block, single_block vs Modular Content vs Structured Text, references vs embedded blocks, taxonomy shape.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-content-modeling.zip",
-      "digest": "sha256:5ff3036631ceea4d8de7b870e823582b57a1643f94baed13d28faea959fde829"
-    },
-    {
-      "name": "datocms-feedback",
-      "type": "archive",
-      "description": "Draft sanitized feedback emails to support@datocms.com about frustrating DatoCMS skills or MCP experiences. Use only when users explicitly ask to report, email, or summarize feedback about DatoCMS skills/MCP.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-feedback.zip",
-      "digest": "sha256:95d165831da274506605bed1496528355d266e9862798ed22200283179103b4f"
-    },
-    {
-      "name": "datocms-frontend-integrations",
-      "type": "archive",
-      "description": "Patch, extend, or explain DatoCMS front-end integration code in existing web projects (Next.js App Router, Nuxt, SvelteKit, Astro, plus React/Vue/Svelte components). Covers draft mode endpoints, Preview Links, Visual Editing, Content Link overlays, real-time preview subscriptions, cache-tag invalidation, and crawler-safe SEO wiring.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-frontend-integrations.zip",
-      "digest": "sha256:047ec255203340d35ee0a5b892a200ad63cba0bc7c47b11031283f7b3fea3b4d"
-    },
-    {
-      "name": "datocms-plugin",
-      "type": "archive",
-      "description": "Build, scaffold, maintain, or restyle DatoCMS plugins built with datocms-plugin-sdk and datocms-react-ui. Covers plugin hooks, field extensions, config screens, sidebars, pages, modals, asset sources, dropdown actions, lifecycle hooks, and dark mode.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-plugin.zip",
-      "digest": "sha256:09da36b71369409000fe8a35900cf4bbe03988fba4e244e724e68bf50781a472"
-    },
-    {
-      "name": "datocms-setup",
-      "type": "archive",
-      "description": "Single entry point for one-shot, end-to-end DatoCMS project setup — bundles prerequisites, chains recipes, takes a greenfield or partial project to working state in one pass. Covers frontend foundation (Next.js/Nuxt/SvelteKit/Astro), frontend features (draft mode, visual editing, real-time updates, SEO), migrations, and CI/CD wiring.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/86c533b74c2913e590797eb0b2622d2cdfe5cf68/zips/datocms-setup.zip",
-      "digest": "sha256:5eb5f7f555475c9d2df7b3e45b1779e8b338170588ae471e07d57f9c5dc32d75"
+      "description": "DatoCMS guidance for content modeling, GraphQL queries, content management, CLI workflows, frontend integrations, plugin development, setup, and feedback. Installs one self-contained skill with selectively loaded topic references.",
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/b22e0f87d52bd1a20f146191ba760ce46616150e/zips/datocms.zip",
+      "digest": "sha256:f495b97e24479cbae6dbaeeab98381d1ae1cb3959b649f03025ee1973df44efd"
     }
   ]
 }

--- a/src/documents/well-known/agent-skills/index.json
+++ b/src/documents/well-known/agent-skills/index.json
@@ -5,8 +5,8 @@
       "name": "datocms",
       "type": "archive",
       "description": "DatoCMS guidance for content modeling, GraphQL queries, content management, CLI workflows, frontend integrations, plugin development, setup, and feedback. Installs one self-contained skill with selectively loaded topic references.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/cf3d1bd2af63c95d657fa80f7c242827c689db7f/zips/datocms.zip",
-      "digest": "sha256:f32f5686bfea15aa4ad1fd025cdaa053c63cdc7fcbe3cab6fbcb063f10aff392"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/85199280596f8679f4b78d6b48ea7cfa4d15b4ca/zips/datocms.zip",
+      "digest": "sha256:7470d28735b60f52e6244daf9d9b1aff18009b414524bce54970664b52388f24"
     }
   ]
 }

--- a/src/documents/well-known/agent-skills/index.json
+++ b/src/documents/well-known/agent-skills/index.json
@@ -5,8 +5,8 @@
       "name": "datocms",
       "type": "archive",
       "description": "DatoCMS guidance for content modeling, GraphQL queries, content management, CLI workflows, frontend integrations, plugin development, setup, and feedback. Installs one self-contained skill with selectively loaded topic references.",
-      "url": "https://raw.githubusercontent.com/datocms/agent-skills/b22e0f87d52bd1a20f146191ba760ce46616150e/zips/datocms.zip",
-      "digest": "sha256:f495b97e24479cbae6dbaeeab98381d1ae1cb3959b649f03025ee1973df44efd"
+      "url": "https://raw.githubusercontent.com/datocms/agent-skills/cf3d1bd2af63c95d657fa80f7c242827c689db7f/zips/datocms.zip",
+      "digest": "sha256:f32f5686bfea15aa4ad1fd025cdaa053c63cdc7fcbe3cab6fbcb063f10aff392"
     }
   ]
 }

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -9,7 +9,7 @@ const BLOCKQUOTE =
 
 const AGENTS_SECTION = (url: (path: string) => string) => `## For agents
 
-- [Agent skills](${url('/.well-known/agent-skills/index.json')}): Index of skills for AI coding agents working with DatoCMS projects
+- [DatoCMS skill](${url('/.well-known/agent-skills/index.json')}): One self-contained skill for DatoCMS coding tasks, with selectively loaded topic references
 - [API catalog](${url('/.well-known/api-catalog')}): Machine-readable catalog of DatoCMS APIs for agent discovery
 - [MCP server card](${url('/.well-known/mcp.json')}): JSON card describing the DatoCMS MCP server
 - [MCP server](https://mcp.datocms.com): Let Claude and other AI assistants chat with your DatoCMS projects


### PR DESCRIPTION
Advertise one self-contained `datocms` skill instead of eight separate downloads. Pin the archive to immutable revision `1a159af6339138edd1331bc716e77db6644e16d0` and calculate its SHA-256 digest from those exact bytes. Update the discovery copy and require a single unified archive in the checker.

Stacked on https://github.com/datocms/astro-website/pull/118; depends on https://github.com/datocms/agent-skills/pull/12. Deploy and verify that preparation before the package migration; merge and deploy this follow-up after the unified artifact is available. Verify production discovery and CDN invalidation during rollout.

Use Vitest for the checker tests and the focused test command so they run under the repository's existing test runner. Validation on Node 22: seven discovery checker tests, exact archive download and digest verification, all 173 archive files compared with the skill source, full formatting check, Astro check, and diff checks.
